### PR TITLE
Allow disabling of automatic trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,14 @@ config.Delim = "|"
 config.Glue = "  "
 config.Prefix = ""
 config.Empty = ""
+config.NoTrim = false
 ```
 
 * `Delim` is the string by which columns of **input** are delimited
 * `Glue` is the string by which columns of **output** are delimited
 * `Prefix` is a string by which each line of **output** is prefixed
 * `Empty` is a string used to replace blank values found in output
+* `NoTrim` is a boolean used to disable the automatic trimming of input values
 
 You can then pass the `Config` in using the `Format` method (signature below) to
 have text formatted to your liking.

--- a/columnize.go
+++ b/columnize.go
@@ -18,6 +18,9 @@ type Config struct {
 
 	// A replacement string to replace empty fields
 	Empty string
+
+	// NoTrim disables automatic trimming of the inputs.
+	NoTrim bool
 }
 
 // Returns a Config with default values.
@@ -35,7 +38,10 @@ func getElementsFromLine(config *Config, line string) []interface{} {
 	seperated := strings.Split(line, config.Delim)
 	elements := make([]interface{}, len(seperated))
 	for i, field := range seperated {
-		value := strings.TrimSpace(field)
+		value := field
+		if !config.NoTrim {
+			value = strings.TrimSpace(field)
+		}
 		if value == "" && config.Empty != "" {
 			value = config.Empty
 		}
@@ -106,6 +112,9 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.Empty != "" {
 		result.Empty = b.Empty
+	}
+	if b.NoTrim {
+		result.NoTrim = true
 	}
 
 	return &result

--- a/columnize_test.go
+++ b/columnize_test.go
@@ -132,6 +132,24 @@ func TestVariedInputSpacing(t *testing.T) {
 	}
 }
 
+func TestVariedInputSpacing_NoTrim(t *testing.T) {
+	input := []string{
+		"Column A|Column B|Column C",
+		"x|y|  z",
+	}
+
+	config := DefaultConfig()
+	config.NoTrim = true
+	output := Format(input, config)
+
+	expected := "Column A  Column B  Column C\n"
+	expected += "x         y           z"
+
+	if output != expected {
+		t.Fatalf("\nexpected:\n%s\n\ngot:\n%s", expected, output)
+	}
+}
+
 func TestUnmatchedColumnCounts(t *testing.T) {
 	input := []string{
 		"Column A | Column B | Column C",


### PR DESCRIPTION
This PR exposes a config option that allows the disabling of the
automatic trimming behavior. The motivation behind this option is to
support things like:

```
Version = 2
Stable  = false
Diff    =
+/- Job: "example"
+/- Task Group: "cache"
  +/- RestartPolicy {
    +/- Attempts: "9" => "10"
        Delay:    "25000000000"
        Interval: "300000000000"
        Mode:     "delay"
      }
      Task: "redis"

Version = 1
Stable  = false
Diff    =
+/- Job: "example"
+/- Task Group: "cache"
  +/- RestartPolicy {
    +/- Attempts: "8" => "9"
        Delay:    "25000000000"
        Interval: "300000000000"
        Mode:     "delay"
      }
      Task: "redis"
```

Without the option the output would be:
```
Version = 2
Stable  = false
Diff    = +/- Job: "example"
+/- Task Group: "cache"
  +/- RestartPolicy {
    +/- Attempts: "9" => "10"
        Delay:    "25000000000"
        Interval: "300000000000"
        Mode:     "delay"
      }
      Task: "redis"

Version = 1
Stable  = false
Diff    = +/- Job: "example"
+/- Task Group: "cache"
  +/- RestartPolicy {
    +/- Attempts: "8" => "9"
        Delay:    "25000000000"
        Interval: "300000000000"
        Mode:     "delay"
      }
      Task: "redis"
```