### PR TITLE
Allow disabling of automatic trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,14 @@ config.Delim = "|"
 config.Glue = "  "
 config.Prefix = ""
 config.Empty = ""
+config.NoTrim = false
 ```
 
 * `Delim` is the string by which columns of **input** are delimited
 * `Glue` is the string by which columns of **output** are delimited
 * `Prefix` is a string by which each line of **output** is prefixed
 * `Empty` is a string used to replace blank values found in output
+* `NoTrim` is a boolean used to disable the automatic trimming of input values
 
 You can then pass the `Config` in using the `Format` method (signature below) to
 have text formatted to your liking.

--- a/columnize.go
+++ b/columnize.go
@@ -18,8 +18,11 @@ type Config struct {
 	// The string by which columns of output will be prefixed.
 	Prefix string
 
-	// A replacement string to replace empty fields
+	// A replacement string to replace empty fields.
 	Empty string
+
+	// NoTrim disables automatic trimming of inputs.
+	NoTrim bool
 }
 
 // DefaultConfig returns a *Config with default values.
@@ -29,6 +32,7 @@ func DefaultConfig() *Config {
 		Glue:   "  ",
 		Prefix: "",
 		Empty:  "",
+		NoTrim: false,
 	}
 }
 
@@ -53,6 +57,9 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.Empty != "" {
 		result.Empty = b.Empty
+	}
+	if b.NoTrim {
+		result.NoTrim = true
 	}
 
 	return &result
@@ -86,7 +93,10 @@ func elementsFromLine(config *Config, line string) []interface{} {
 	separated := strings.Split(line, config.Delim)
 	elements := make([]interface{}, len(separated))
 	for i, field := range separated {
-		value := strings.TrimSpace(field)
+		value := field
+		if !config.NoTrim {
+			value = strings.TrimSpace(field)
+		}
 
 		// Apply the empty value, if configured.
 		if value == "" && config.Empty != "" {

--- a/columnize_test.go
+++ b/columnize_test.go
@@ -155,6 +155,24 @@ func TestVariedInputSpacing(t *testing.T) {
 	}
 }
 
+func TestVariedInputSpacing_NoTrim(t *testing.T) {
+	input := []string{
+		"Column A|Column B|Column C",
+		"x|y|  z",
+	}
+
+	config := DefaultConfig()
+	config.NoTrim = true
+	output := Format(input, config)
+
+	expected := "Column A  Column B  Column C\n"
+	expected += "x         y           z"
+
+	if output != expected {
+		t.Fatalf("\nexpected:\n%s\n\ngot:\n%s", expected, output)
+	}
+}
+
 func TestUnmatchedColumnCounts(t *testing.T) {
 	input := []string{
 		"Column A | Column B | Column C",


### PR DESCRIPTION
This PR exposes a config option that allows the disabling of the
automatic trimming behavior. The motivation behind this option is to
support things like:

```
Version = 2
Stable  = false
Diff    =
+/- Job: "example"
+/- Task Group: "cache"
  +/- RestartPolicy {
    +/- Attempts: "9" => "10"
        Delay:    "25000000000"
        Interval: "300000000000"
        Mode:     "delay"
      }
      Task: "redis"

Version = 1
Stable  = false
Diff    =
+/- Job: "example"
+/- Task Group: "cache"
  +/- RestartPolicy {
    +/- Attempts: "8" => "9"
        Delay:    "25000000000"
        Interval: "300000000000"
        Mode:     "delay"
      }
      Task: "redis"
```

Without the option the output would be:
```
Version = 2
Stable  = false
Diff    = +/- Job: "example"
+/- Task Group: "cache"
  +/- RestartPolicy {
    +/- Attempts: "9" => "10"
        Delay:    "25000000000"
        Interval: "300000000000"
        Mode:     "delay"
      }
      Task: "redis"

Version = 1
Stable  = false
Diff    = +/- Job: "example"
+/- Task Group: "cache"
  +/- RestartPolicy {
    +/- Attempts: "8" => "9"
        Delay:    "25000000000"
        Interval: "300000000000"
        Mode:     "delay"
      }
      Task: "redis"
```